### PR TITLE
Refactor NFT action modals and connection handling

### DIFF
--- a/src/components/buySell-page/buysellpage.tsx
+++ b/src/components/buySell-page/buysellpage.tsx
@@ -12,7 +12,6 @@ import {
   Box,
   Image,
   Button,
-  Tooltip,
 } from "@chakra-ui/react";
 
 import { client } from "@/consts/client";
@@ -33,7 +32,7 @@ import {
 import { getOwnedTokenIds, isApprovedForAll } from "thirdweb/extensions/erc721";
 import { hederaMainnet } from "@/consts/chains";
 
-// Optional local actions (kept for live compatibility if you reuse logic)
+// Local listing/auction (kept for live compatibility if you want to reuse logic inside modals)
 import CreateListingLocal from "@/components/buySell-page/CreateListingLocal";
 import CreateAuction from "@/components/auctions/CreateAuction";
 
@@ -47,7 +46,7 @@ import AuctionNftModal from "@/components/modals/AuctionNftModal";
 
 type Props = {
   address?: string; // collection address may be empty/invalid; fallback to local view
-  chain?: Chain;    // optional chain; defaults to hederaMainnet
+  chain?: Chain; // optional chain; defaults to hederaMainnet
 };
 
 type Trait = { trait_type?: string; value?: any; display_type?: string };
@@ -146,6 +145,8 @@ const PAGE_SIZE = 5;
 
 export default function BuySellPage({ address, chain }: Props) {
   const account = useActiveAccount();
+  const isConnected = !!account?.address; // single source of truth for connection state
+
   const activeChain = useActiveWalletChain();
   const switchChain = useSwitchActiveWalletChain();
 
@@ -218,28 +219,40 @@ export default function BuySellPage({ address, chain }: Props) {
   const [listOpen, setListOpen] = useState(false);
   const [auctionOpen, setAuctionOpen] = useState(false);
 
-  // Connection guard
-  const isConnected = !!account?.address;
+  // Toggle a single action modal and ensure others are closed.
+  // When not connected, do nothing (modals will not open).
+  function toggleModal(which: "send" | "list" | "auction") {
+    if (!isConnected) return;
 
-  // Centralized opener: prevents opening when wallet is disconnected
-  function openAction(which: "send" | "list" | "auction") {
-    if (!isConnected) {
-      window.alert("Connect a wallet to continue.");
-      return;
+    if (which === "send") {
+      setSendOpen((v) => {
+        const next = !v;
+        if (next) {
+          setListOpen(false);
+          setAuctionOpen(false);
+        }
+        return next;
+      });
+    } else if (which === "list") {
+      setListOpen((v) => {
+        const next = !v;
+        if (next) {
+          setSendOpen(false);
+          setAuctionOpen(false);
+        }
+        return next;
+      });
+    } else {
+      setAuctionOpen((v) => {
+        const next = !v;
+        if (next) {
+          setSendOpen(false);
+          setListOpen(false);
+        }
+        return next;
+      });
     }
-    setSendOpen(which === "send");
-    setListOpen(which === "list");
-    setAuctionOpen(which === "auction");
   }
-
-  // Close action modals when wallet disconnects
-  useEffect(() => {
-    if (!isConnected) {
-      setSendOpen(false);
-      setListOpen(false);
-      setAuctionOpen(false);
-    }
-  }, [isConnected]);
 
   // Close modals when selection changes
   useEffect(() => {
@@ -310,7 +323,7 @@ export default function BuySellPage({ address, chain }: Props) {
     }
   }
 
-  // Example send (live) - remains here if you wire it into SendNftModal later
+  // Example send (live). Kept for potential reuse in SendNftModal.
   async function handleSend() {
     if (useLocalFallback) {
       setStatus("Sending is not available in this view.");
@@ -359,8 +372,10 @@ export default function BuySellPage({ address, chain }: Props) {
 
       <CardBody>
         <Box mb="4">
-          <Text color="chakra-body-text">Your wallet NFTs for this collection:</Text>
-          {!account?.address ? (
+          <Text color="chakra-body-text">
+            Your wallet NFTs for this collection:
+          </Text>
+          {!isConnected ? (
             <Text fontSize="sm" mt="2">
               Connect a wallet using the header button.
             </Text>
@@ -388,10 +403,19 @@ export default function BuySellPage({ address, chain }: Props) {
               p="2"
               rounded="md"
               cursor="pointer"
-              bg={selectedNFT?.id === nft.id ? "chakra-subtle-bg" : "chakra-body-bg"}
+              bg={
+                selectedNFT?.id === nft.id
+                  ? "chakra-subtle-bg"
+                  : "chakra-body-bg"
+              }
               onClick={() => setSelectedNFT(nft)}
             >
-              <Image src={nft.image} alt={nft.title} boxSize="96px" objectFit="cover" />
+              <Image
+                src={nft.image}
+                alt={nft.title}
+                boxSize="96px"
+                objectFit="cover"
+              />
               <Text mt="2" noOfLines={1} color="chakra-body-text">
                 {nft.title}
               </Text>
@@ -463,93 +487,74 @@ export default function BuySellPage({ address, chain }: Props) {
           <Box mt="6">
             <Text color="chakra-body-text">Action:</Text>
 
-            {/* Approval (real contract only) */}
-            {!useLocalFallback && (
-              <Box mt="2">
-                {!/^0x[a-fA-F0-9]{40}$/.test(MARKETPLACE_ADDRESS) ? (
-                  <Text color="orange.500" fontSize="sm">
-                    Marketplace address not configured.
-                  </Text>
-                ) : isLoadingApproval ? (
-                  <Text fontSize="sm">Checking approval…</Text>
-                ) : isApproved ? (
-                  <Text fontSize="sm" color="green.500">
-                    Marketplace approved for this collection.
-                  </Text>
-                ) : (
-                  <TransactionButton
-                    transaction={async () => {
-                      // ensure user is on the right chain
-                      if (activeChain?.id !== effectiveChain.id) {
-                        await switchChain(effectiveChain);
-                      }
-                      return prepareContractCall({
-                        contract: realContract!, // safe here
-                        method: "setApprovalForAll",
-                        params: [MARKETPLACE_ADDRESS, true],
-                      });
-                    }}
-                    onTransactionConfirmed={() => {
-                      refetchApproval();
-                    }}
-                    style={{ marginTop: 8 }}
-                  >
-                    Approve Marketplace
-                  </TransactionButton>
+            {/* If not connected, show a hint and DO NOT render buttons */}
+            {!isConnected ? (
+              <Text mt="2" fontSize="sm" color="gray.500">
+                Connect a wallet to send, sell or auction this NFT.
+              </Text>
+            ) : (
+              <>
+                {/* Approval (real contract only) */}
+                {!useLocalFallback && (
+                  <Box mt="2">
+                    {!/^0x[a-fA-F0-9]{40}$/.test(MARKETPLACE_ADDRESS) ? (
+                      <Text color="orange.500" fontSize="sm">
+                        Marketplace address not configured.
+                      </Text>
+                    ) : isLoadingApproval ? (
+                      <Text fontSize="sm">Checking approval…</Text>
+                    ) : isApproved ? (
+                      <Text fontSize="sm" color="green.500">
+                        Marketplace approved for this collection.
+                      </Text>
+                    ) : (
+                      <TransactionButton
+                        transaction={async () => {
+                          if (activeChain?.id !== effectiveChain.id) {
+                            await switchChain(effectiveChain);
+                          }
+                          return prepareContractCall({
+                            contract: realContract!,
+                            method: "setApprovalForAll",
+                            params: [MARKETPLACE_ADDRESS, true],
+                          });
+                        }}
+                        onTransactionConfirmed={() => {
+                          refetchApproval();
+                        }}
+                        style={{ marginTop: 8 }}
+                      >
+                        Approve Marketplace
+                      </TransactionButton>
+                    )}
+                  </Box>
                 )}
-              </Box>
+
+                {/* Action buttons (only when connected) */}
+
+                <Flex gap="3" mt="4">
+                  {/* Enable Send even in fallback so the modal opens.
+                    The modal itself keeps "Confirm send" disabled via forceDisableConfirm. */}
+                  <Button colorScheme="red" onClick={() => toggleModal("send")}>
+                    Send
+                  </Button>
+
+                  <Button
+                    colorScheme="purple"
+                    onClick={() => toggleModal("list")}
+                  >
+                    Sell
+                  </Button>
+
+                  <Button
+                    colorScheme="orange"
+                    onClick={() => toggleModal("auction")}
+                  >
+                    Auction
+                  </Button>
+                </Flex>
+              </>
             )}
-
-            {/* Open action modals (guarded and disabled when disconnected) */}
-          {/* Action triggers with hover tooltip when disconnected */}
-<Flex gap="3" mt="4">
-  {/* Send */}
-  <Tooltip
-    // Disable the tooltip when connected so it doesn't show
-    isDisabled={isConnected}
-    label="Connect a wallet."
-    placement="top"
-    hasArrow
-  >
-    {/* Wrap disabled Button in a span so Tooltip can attach hover events */}
-    <span>
-      <Button
-        colorScheme="red"
-        onClick={() => openAction("send")}
-        isDisabled={!isConnected}
-      >
-        Send
-      </Button>
-    </span>
-  </Tooltip>
-
-  {/* Sell */}
-  <Tooltip isDisabled={isConnected} label="Connect a wallet." placement="top" hasArrow>
-    <span>
-      <Button
-        colorScheme="purple"
-        onClick={() => openAction("list")}
-        isDisabled={!isConnected}
-      >
-        Sell
-      </Button>
-    </span>
-  </Tooltip>
-
-  {/* Auction */}
-  <Tooltip isDisabled={isConnected} label="Connect a wallet." placement="top" hasArrow>
-    <span>
-      <Button
-        colorScheme="orange"
-        onClick={() => openAction("auction")}
-        isDisabled={!isConnected}
-      >
-        Auction
-      </Button>
-    </span>
-  </Tooltip>
-</Flex>
-
           </Box>
         )}
 
@@ -567,20 +572,25 @@ export default function BuySellPage({ address, chain }: Props) {
           chain={hederaMainnet}
         />
 
-        {/* Action Modals (never open when disconnected) */}
+        {/* Action Modals (they remain mounted but cannot be opened when disconnected) */}
         <SendNftModal
-          isOpen={sendOpen && isConnected}
+          isOpen={sendOpen}
           onClose={() => setSendOpen(false)}
           chain={hederaMainnet}
           name={selectedNFT?.title}
           image={selectedNFT?.image}
           tokenId={selectedNFT?.id}
           collection={address || ""}
-          // Hook up onSubmit to handleSend() when you go live
+          // pass connection state so the modal can show hints
+          isWalletConnected={isConnected}
+          // demo: keep Confirm disabled even if wallet is connected
+          forceDisableConfirm={true}
+          forceDisableReason="Sending is disabled in this demo. It will be enabled for live."
+          // onConfirm={(to) => handleSend()} // enable this on live
         />
 
         <ListNftModal
-          isOpen={listOpen && isConnected}
+          isOpen={listOpen}
           onClose={() => setListOpen(false)}
           name={selectedNFT?.title}
           image={selectedNFT?.image}
@@ -590,7 +600,7 @@ export default function BuySellPage({ address, chain }: Props) {
         />
 
         <AuctionNftModal
-          isOpen={auctionOpen && isConnected}
+          isOpen={auctionOpen}
           onClose={() => setAuctionOpen(false)}
           name={selectedNFT?.title}
           image={selectedNFT?.image}

--- a/src/components/modals/SendNftModal.tsx
+++ b/src/components/modals/SendNftModal.tsx
@@ -11,23 +11,48 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   chain: Chain;
-  isWalletConnected?: boolean;
+  isWalletConnected?: boolean;     // NEW: connection state
   name?: string;
   image?: string;
   tokenId?: string;
   collection: string;
   onConfirm?: (to: string) => void; // optional live hook
+
+  // NEW: force the confirm button to stay disabled (demo mode)
+  forceDisableConfirm?: boolean;
+  forceDisableReason?: string;
 };
 
 export default function SendNftModal({
-  isOpen, onClose, chain, isWalletConnected,
-  name, image, tokenId, collection, onConfirm,
+  isOpen,
+  onClose,
+  chain,
+  isWalletConnected,
+  name,
+  image,
+  tokenId,
+  collection,
+  onConfirm,
+  forceDisableConfirm,
+  forceDisableReason,
 }: Props) {
   const [to, setTo] = useState("");
+
+  // If forceDisableConfirm is true, the confirm button is always disabled.
   const canConfirm = useMemo(() => {
-    // Disable confirm if wallet not connected or no receiver entered
+    if (forceDisableConfirm) return false;
     return !!isWalletConnected && !!to;
-  }, [isWalletConnected, to]);
+  }, [forceDisableConfirm, isWalletConnected, to]);
+
+  // Helper text explaining why the confirm is disabled
+  const disableHint =
+    forceDisableConfirm
+      ? (forceDisableReason || "Sending is disabled.")
+      : !isWalletConnected
+        ? "Connect a wallet to confirm the transfer."
+        : !to
+          ? "Enter a destination address to continue."
+          : "";
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} isCentered size="md">
@@ -64,16 +89,18 @@ export default function SendNftModal({
               value={to}
               onChange={(e) => setTo(e.target.value)}
             />
-            {!isWalletConnected && (
+            {disableHint && (
               <Text mt="2" fontSize="sm" color="orange.500">
-                Connect a wallet to confirm the transfer.
+                {disableHint}
               </Text>
             )}
           </Box>
         </ModalBody>
 
         <ModalFooter>
-          <Button variant="ghost" mr={3} onClick={onClose}>Cancel</Button>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
           <Button
             colorScheme="red"
             onClick={() => {


### PR DESCRIPTION
Reworked BuySellPage to centralize wallet connection state and refactored modal toggling logic to prevent opening action modals when disconnected. Removed Tooltip wrappers from action buttons and added explicit connection hints. Updated SendNftModal to support forced disabling of the confirm button for demo mode, with improved user feedback for disabled states.